### PR TITLE
extra code rm; deadlock

### DIFF
--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"sync"
 	"testing"
 
@@ -235,4 +236,17 @@ func TestManySubscribesWithManyPublishers(tt *testing.T) {
 		}
 		t.Equal(subMsgCounter, 1000)
 	}
+}
+
+func TestSubscribeDeadlock(tt *testing.T) {
+	t := check.T(tt)
+	s := NewServer()
+	topic := "topic"
+	subscriber := "sub"
+	msg, err := s.Poll(topic, subscriber)
+	t.Nil(msg)
+	t.Equal(err, ErrSubscriptionNotFound)
+
+	s.Subscribe(topic, subscriber)
+	log.Fatalf("Line is not reacheable")
 }

--- a/server.go
+++ b/server.go
@@ -18,11 +18,11 @@ func (s *Server) Subscribe(topic string, subscriber string) {
 	s.m.Lock()
 	cl := s.clients[sn]
 	if cl == nil {
-		cl = s.clients[sn]
-		if cl == nil {
-			cl = newClient()
-			s.clients[sn] = cl
-		}
+		// cl = s.clients[sn]
+		// if cl == nil {
+		cl = newClient()
+		s.clients[sn] = cl
+		// }
 	}
 	cl.subscribe(tn)
 	clients := s.topics[tn]


### PR DESCRIPTION
Plus, overall notes:

- messages store could have been more efficient without duplicating data across all subscribers;
- inconsistent use of `defer` on mutexes;
- plain `golint` has one warning.